### PR TITLE
use jquery 3.2.1 to fix picture missing issue

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -17,7 +17,7 @@
     "tests"
   ],
   "dependencies": {
-    "jquery": "~2.1.0",
+    "jquery": "~3.2.1",
     "angular": "~1.3.15",
     "angular-animate": "~1.3.15",
     "angular-ui-router": "~0.2.12",


### PR DESCRIPTION
Original jquery version will cause unsafe-eval and hence pictures in articles failed to be converted to blob.
Updated to jquery 3.2.1 can fix this.